### PR TITLE
Fix Enable Interrupts Call

### DIFF
--- a/src/idt/idt.asm
+++ b/src/idt/idt.asm
@@ -6,6 +6,18 @@ extern no_interrupt_handler
 global idt_load         ; export the symbol idt_load in order to use it in .c files
 global int21h
 global no_interrupt
+global enable_interrupts
+global disable_interrupts
+
+; Enable Interrups should be after setting IDT in order to prevent PANIC scenarios
+enable_interrupts:
+    sti
+    ret
+
+; Disable interrupts
+disable_interrupts:
+    cli
+    ret
 
 idt_load:
     push ebp

--- a/src/idt/idt.c
+++ b/src/idt/idt.c
@@ -69,7 +69,7 @@ void idt_init()
     // interrupt 0x20 is the timer interrupt after we remap the IRQs to address 0x20
     //idt_set(0x20, int21h);
     // interrupt 0x21 is the keyboard interrupt after we remap the IRQs to address 0x20
-    //idt_set(0x21, int21h);
+    idt_set(0x21, int21h);
 
     // Load IDT
     idt_load(&idtr_descriptor);

--- a/src/idt/idt.h
+++ b/src/idt/idt.h
@@ -23,5 +23,7 @@ struct idtr_desc
 } __attribute__((packed));
 
 void idt_init();
+void enable_interrupts();
+void disable_interrupts();
 
 #endif  // IDT_H

--- a/src/kernel.asm
+++ b/src/kernel.asm
@@ -33,9 +33,6 @@ _start:
     out 0x21, al
     ; End of remappin the master PIC
 
-    ; Enable interrupts
-    sti
-
     call kernel_main
     jmp $
 

--- a/src/kernel.c
+++ b/src/kernel.c
@@ -75,10 +75,13 @@ void kernel_main()
     terminal_initialize();
     print("Hello world!\n");
 
-    // initialize the heap
+    // Initialize the heap
     kheap_init();
 
-    // initialize the Interrupt Descriptor Table (IDT)
+    // Initialize the Interrupt Descriptor Table (IDT)
     idt_init();
+
+    // Enable interrupts must be after initializing the IDT in order to prevent PANIC scenarios
+    enable_interrupts();
 
 }


### PR DESCRIPTION
moved enable_interrupts to be called after initializing the IDT in order to avoid PANIC scenarios (in case interrupts occur when IDT is initialized and loaded yet)